### PR TITLE
Add support for building in linux

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 authors = ["Andrew Jones <andy.larrymite@gmail.com>"]
 edition = "2018"
 description = "A Tetris clone with a deliberately frustrating set of blocks."
-license = "MIT"
-build = "build.rs"
 
 [dependencies]
 rand = "0.7.3"
@@ -13,17 +11,22 @@ rand = "0.7.3"
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
 
-[dependencies.sdl2]
+[target.'cfg(target_os = "linux")'.dependencies.sdl2]
+version = "0.34.3"
+default-features = false
+features = ["ttf", "mixer"]
+
+[target.'cfg(not(target_os = "linux"))'.dependencies.sdl2]
 version = "0.34.3"
 default-features = false
 features = ["ttf", "mixer", "static-link", "use-vcpkg"]
 
-[package.metadata.vcpkg]
+[target.'cfg(not(target_os = "linux"))'.package.metadata.vcpkg]
 dependencies = ["sdl2", "sdl2-ttf", "sdl2-mixer[libvorbis]"]
 git = "https://github.com/microsoft/vcpkg"
 rev = "a0518036077baa4"
 
-[package.metadata.vcpkg.target]
+[target.'cfg(not(target_os = "linux"))'.package.metadata.vcpkg.target]
 x86_64-pc-windows-msvc = { triplet = "x64-windows-static-md" }
 
 [package.metadata.bundle]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ winres = "0.1"
 [target.'cfg(target_os = "linux")'.dependencies.sdl2]
 version = "0.34.3"
 default-features = false
-features = ["ttf", "mixer"]
+features = ["ttf", "mixer", "static-link", "use-pkgconfig"]
 
 [target.'cfg(not(target_os = "linux"))'.dependencies.sdl2]
 version = "0.34.3"

--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ cargo install cargo-vcpkg
 cargo vcpkg build
 ```
 
-## Compile and run
+## Compile and run - MacOS and Windows
 
 ```bash
 cargo run --release
 ```
+
+## Compile and run - Linux
+```bash
+rustup install nightly
+cargo +nightly -Z features=itarget run 
+```
+
+(once the -Z flag is merged into cargo stable the rustup command and +nightly won't be required.)
 
 Enjoy!
 


### PR DESCRIPTION
- Exclude the VCPKG provided version of SDL2 in linux only and use standard rust-sdl2

In linux the VCPKG crate version of SDL2[vorbis] doesn't link correctly so the project doesn't build. As SDL2 libs can be trivially installed and linked via the package manager in linux I've added dependency config in Cargo.toml to just use normal dependencies for rust-sdl2 and added config to exclude the VCPKG version of the dependencies for linux so that it will still apply for macos and windows.